### PR TITLE
Rebuild portfolio as static HTML experience

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# portfolio

--- a/app.js
+++ b/app.js
@@ -1,0 +1,257 @@
+const state = {
+  reduceMotion: window.matchMedia('(prefers-reduced-motion: reduce)')
+};
+
+const onReady = () => {
+  const yearEl = document.getElementById('year');
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
+
+  const introMask = document.querySelector('.intro-mask');
+  if (introMask) {
+    if (state.reduceMotion.matches) {
+      introMask.remove();
+    } else {
+      requestAnimationFrame(() => {
+        introMask.classList.add('is-hidden');
+        introMask.addEventListener('transitionend', () => introMask.remove(), { once: true });
+      });
+    }
+  }
+
+  setupHeaderGlass();
+  setupReveals();
+  setupMagneticCTA();
+  setupParticles();
+  setupForm();
+};
+
+const setupHeaderGlass = () => {
+  const header = document.querySelector('.site-header');
+  if (!header) return;
+  const toggle = () => {
+    if (window.scrollY > 8) {
+      header.classList.add('is-glass');
+    } else {
+      header.classList.remove('is-glass');
+    }
+  };
+  toggle();
+  window.addEventListener('scroll', toggle, { passive: true });
+};
+
+const setupReveals = () => {
+  const elements = Array.from(document.querySelectorAll('.reveal'));
+  if (!elements.length) return;
+
+  if (state.reduceMotion.matches) {
+    elements.forEach((el) => el.classList.add('visible'));
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const index = elements.indexOf(entry.target);
+          setTimeout(() => entry.target.classList.add('visible'), index * 120);
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.2 }
+  );
+
+  elements.forEach((el) => observer.observe(el));
+};
+
+const setupMagneticCTA = () => {
+  const button = document.querySelector('.btn-magnetic');
+  if (!button || state.reduceMotion.matches) return;
+
+  const strength = 16;
+  const reset = () => {
+    button.style.transform = 'translate3d(0, 0, 0)';
+  };
+
+  button.addEventListener('pointermove', (event) => {
+    const rect = button.getBoundingClientRect();
+    const x = event.clientX - rect.left - rect.width / 2;
+    const y = event.clientY - rect.top - rect.height / 2;
+    button.style.transform = `translate3d(${(x / rect.width) * strength}px, ${(y / rect.height) * strength}px, 0)`;
+  });
+
+  button.addEventListener('pointerleave', reset);
+  button.addEventListener('blur', reset);
+};
+
+const setupParticles = () => {
+  const canvas = document.querySelector('.hero-canvas');
+  if (!canvas || state.reduceMotion.matches) {
+    if (canvas) {
+      canvas.remove();
+    }
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  const particles = [];
+  const config = {
+    count: 150,
+    baseSpeed: 0.12,
+    pointerInfluence: 0.035,
+    maxVelocity: 0.6
+  };
+
+  let pointer = { x: 0, y: 0, active: false };
+
+  const applyCanvasSize = () => {
+    const rect = canvas.getBoundingClientRect();
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = rect.width * ratio;
+    canvas.height = rect.height * ratio;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(ratio, ratio);
+  };
+
+  class Particle {
+    constructor(width, height) {
+      this.reset(width, height);
+    }
+    reset(width, height) {
+      this.x = Math.random() * width;
+      this.y = Math.random() * height;
+      const angle = Math.random() * Math.PI * 2;
+      const speed = config.baseSpeed + Math.random() * 0.4;
+      this.vx = Math.cos(angle) * speed;
+      this.vy = Math.sin(angle) * speed;
+      this.size = 1 + Math.random() * 1.5;
+    }
+    update(width, height) {
+      if (pointer.active) {
+        const dx = pointer.x - this.x;
+        const dy = pointer.y - this.y;
+        const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 0.01);
+        const force = config.pointerInfluence / dist;
+        this.vx += dx * force;
+        this.vy += dy * force;
+      }
+
+      const velocity = Math.sqrt(this.vx * this.vx + this.vy * this.vy);
+      const max = config.maxVelocity;
+      if (velocity > max) {
+        this.vx = (this.vx / velocity) * max;
+        this.vy = (this.vy / velocity) * max;
+      }
+
+      this.x += this.vx;
+      this.y += this.vy;
+
+      if (this.x < -20 || this.x > width + 20 || this.y < -20 || this.y > height + 20) {
+        this.reset(width, height);
+      }
+    }
+    draw(context) {
+      context.beginPath();
+      context.fillStyle = 'rgba(255, 125, 183, 0.35)';
+      context.arc(this.x, this.y, this.size, 0, Math.PI * 2);
+      context.fill();
+    }
+  }
+
+  const initParticles = () => {
+    particles.length = 0;
+    const rect = canvas.getBoundingClientRect();
+    const width = rect.width;
+    const height = rect.height;
+    for (let i = 0; i < config.count; i += 1) {
+      particles.push(new Particle(width, height));
+    }
+  };
+
+  let animationFrame = null;
+
+  const render = () => {
+    const rect = canvas.getBoundingClientRect();
+    ctx.clearRect(0, 0, rect.width, rect.height);
+    particles.forEach((particle) => {
+      particle.update(rect.width, rect.height);
+      particle.draw(ctx);
+    });
+    animationFrame = requestAnimationFrame(render);
+  };
+
+  const handlePointerMove = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    pointer = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+      active: true
+    };
+  };
+
+  const handlePointerLeave = () => {
+    pointer.active = false;
+  };
+
+  const handleResize = () => {
+    applyCanvasSize();
+    initParticles();
+  };
+
+  applyCanvasSize();
+  initParticles();
+  render();
+
+  window.addEventListener('resize', handleResize);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerleave', handlePointerLeave);
+};
+
+const setupForm = () => {
+  const form = document.querySelector('.contact-form');
+  if (!form) return;
+  const status = form.querySelector('.form-status');
+
+  const validators = {
+    nombre: (value) => value.trim().length > 1,
+    email: (value) => /.+@.+\..+/.test(value.trim()),
+    mensaje: (value) => value.trim().length > 5
+  };
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    let isValid = true;
+
+    for (const [name, validate] of Object.entries(validators)) {
+      const field = form.elements.namedItem(name);
+      if (!field) continue;
+      const value = formData.get(name);
+      const valid = validate(String(value || ''));
+      field.setAttribute('aria-invalid', String(!valid));
+      if (!valid) {
+        isValid = false;
+        field.classList.add('input-error');
+      } else {
+        field.classList.remove('input-error');
+      }
+    }
+
+    if (!status) return;
+
+    if (isValid) {
+      status.textContent = 'Gracias por tu mensaje. Te contactaré pronto.';
+      form.reset();
+    } else {
+      status.textContent = 'Revisa los campos resaltados para continuar.';
+    }
+  });
+};
+
+document.addEventListener('DOMContentLoaded', onReady);
+
+state.reduceMotion.addEventListener('change', () => {
+  window.location.reload();
+});

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,13 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Juana Saavedra Monograma</title>
+  <desc id="desc">Monograma circular con iniciales JS y acentos rosados</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FF5DA2" />
+      <stop offset="100%" stop-color="#E9488C" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="none" stroke="url(#grad)" stroke-width="4" />
+  <path d="M38 82c8 8 20 10 28 0 6-7 7-20-4-26l-10-6c-6-4-6-12 0-16 5-3 13-1 16 4" fill="none" stroke="#FF7BB6" stroke-width="6" stroke-linecap="round" />
+  <path d="M73 38v44" stroke="#F3F4F6" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Juana Saavedra · UX + Frontend</title>
+    <meta name="description" content="Portafolio de Juana Saavedra, diseñadora UX y desarrolladora frontend especializada en experiencias interactivas." />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="intro-mask" aria-hidden="true"></div>
+    <header class="site-header" id="top">
+      <div class="container header-inner">
+        <a class="brand" href="#top" aria-label="Juana Saavedra">
+          <img src="assets/logo.svg" alt="Juana Saavedra" width="36" height="36" />
+          <span class="brand-name">Juana Saavedra</span>
+        </a>
+        <nav class="site-nav" aria-label="Principal">
+          <ul>
+            <li><a href="#servicios">Servicios</a></li>
+            <li><a href="#trabajos">Trabajos</a></li>
+            <li><a href="#sobre-mi">Sobre mí</a></li>
+            <li><a href="#contacto">Contacto</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <canvas class="hero-canvas" width="1280" height="720" aria-hidden="true"></canvas>
+        <div class="container hero-content">
+          <p class="eyebrow">Experiencias científicas + frontend</p>
+          <h1 id="hero-title" class="hero-title"><em>Diseño interfaces que combinan rigor y emoción.</em></h1>
+          <p class="hero-subtitle">
+            Exploro datos, diseño sistemas y construyo productos web performantes con una estética elegante y medible.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary btn-magnetic" href="mailto:jusaavedrar@ieee.org">Trabajemos juntos</a>
+            <a class="btn btn-ghost" href="#trabajos">Ver trabajos</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="servicios" class="section" aria-labelledby="servicios-title">
+        <div class="container">
+          <h2 id="servicios-title" class="section-title reveal"><em>Servicios</em></h2>
+          <div class="services-grid">
+            <article class="service-card reveal">
+              <h3><em>UX Research &amp; Strategy</em></h3>
+              <p>Entrevistas, mapas de experiencia y KPIs claros para validar hipótesis y guiar decisiones de producto.</p>
+            </article>
+            <article class="service-card reveal">
+              <h3><em>UI / Design Systems</em></h3>
+              <p>Tokens, componentes accesibles y documentación viva para escalar la consistencia visual.</p>
+            </article>
+            <article class="service-card reveal">
+              <h3><em>Frontend</em></h3>
+              <p>Implementación en React/Next, integración de APIs y rendimiento medido para experiencias fluidas.</p>
+            </article>
+            <article class="service-card reveal">
+              <h3><em>Creative Coding</em></h3>
+              <p>Prototipos WebGL, visualizaciones interactivas y microinteracciones que explican ideas complejas.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="trabajos" class="section" aria-labelledby="trabajos-title">
+        <div class="container">
+          <h2 id="trabajos-title" class="section-title reveal"><em>Trabajos destacados</em></h2>
+          <div class="works-grid">
+            <article class="work-card reveal">
+              <div class="work-media" aria-hidden="true"></div>
+              <div class="work-content">
+                <p class="work-tags">Analytics · R3F</p>
+                <h3><em>Panel de analítica inmersiva</em></h3>
+              </div>
+            </article>
+            <article class="work-card reveal">
+              <div class="work-media" aria-hidden="true"></div>
+              <div class="work-content">
+                <p class="work-tags">Design System · A11y</p>
+                <h3><em>Design system inclusivo</em></h3>
+              </div>
+            </article>
+            <article class="work-card reveal">
+              <div class="work-media" aria-hidden="true"></div>
+              <div class="work-content">
+                <p class="work-tags">AI · Visualización</p>
+                <h3><em>Explicador de IA transparente</em></h3>
+              </div>
+            </article>
+            <article class="work-card reveal">
+              <div class="work-media" aria-hidden="true"></div>
+              <div class="work-content">
+                <p class="work-tags">Fintech · UX</p>
+                <h3><em>Onboarding financiero sin fricción</em></h3>
+              </div>
+            </article>
+            <article class="work-card reveal">
+              <div class="work-media" aria-hidden="true"></div>
+              <div class="work-content">
+                <p class="work-tags">Investigación · Datos</p>
+                <h3><em>Laboratorio de insights colaborativos</em></h3>
+              </div>
+            </article>
+            <article class="work-card reveal">
+              <div class="work-media" aria-hidden="true"></div>
+              <div class="work-content">
+                <p class="work-tags">Educación · WebGL</p>
+                <h3><em>Simulador interactivo de campus</em></h3>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="sobre-mi" class="section" aria-labelledby="sobre-mi-title">
+        <div class="container about">
+          <div class="about-text reveal">
+            <h2 id="sobre-mi-title" class="section-title"><em>Sobre mí</em></h2>
+            <p>
+              Soy Juana Saavedra, ingeniera y diseñadora que combina investigación, sistemas de diseño y desarrollo frontend para crear productos digitales intuitivos y medibles.
+            </p>
+            <p>
+              Trabajo en ciclos iterativos, colaboro con equipos multidisciplinarios y traduzco complejidad técnica en experiencias claras.
+            </p>
+            <ul class="skill-list" aria-label="Habilidades principales">
+              <li>UX Research</li>
+              <li>Prototipado</li>
+              <li>Design Systems</li>
+              <li>React</li>
+              <li>TypeScript</li>
+              <li>WebGL</li>
+              <li>Accesibilidad</li>
+            </ul>
+          </div>
+          <div class="about-logos reveal" aria-label="Colaboraciones destacadas">
+            <svg viewBox="0 0 120 60" role="img" aria-label="Orion Labs">
+              <rect x="5" y="10" width="30" height="40" rx="6" fill="var(--surface)" opacity="0.12" />
+              <path d="M25 20c-7 0-12 5-12 12s5 12 12 12 12-5 12-12-5-12-12-12zm0 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12z" fill="var(--pink-500)" />
+              <text x="48" y="36" fill="var(--ink)" font-size="18" font-family="inherit">Orion</text>
+            </svg>
+            <svg viewBox="0 0 120 60" role="img" aria-label="Helix">
+              <path d="M20 45c20-30 40-30 60 0" fill="none" stroke="var(--pink-500)" stroke-width="4" stroke-linecap="round" />
+              <path d="M20 15c20 30 40 30 60 0" fill="none" stroke="var(--pink-300)" stroke-width="4" stroke-linecap="round" />
+              <circle cx="20" cy="45" r="4" fill="var(--ink)" />
+              <circle cx="80" cy="15" r="4" fill="var(--ink)" />
+              <text x="90" y="34" fill="var(--ink)" font-size="16" font-family="inherit">Helix</text>
+            </svg>
+            <svg viewBox="0 0 120 60" role="img" aria-label="Nova AI">
+              <polygon points="20,30 40,10 60,30 40,50" fill="var(--pink-600)" opacity="0.6" />
+              <polygon points="60,30 80,10 100,30 80,50" fill="var(--pink-500)" opacity="0.4" />
+              <text x="24" y="56" fill="var(--ink)" font-size="14" font-family="inherit">Nova AI</text>
+            </svg>
+          </div>
+        </div>
+      </section>
+
+      <section id="contacto" class="section" aria-labelledby="contacto-title">
+        <div class="container">
+          <h2 id="contacto-title" class="section-title reveal"><em>Contacto</em></h2>
+          <form class="contact-form reveal" novalidate>
+            <div class="form-field">
+              <label for="nombre">Nombre</label>
+              <input type="text" id="nombre" name="nombre" autocomplete="name" required />
+            </div>
+            <div class="form-field">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" autocomplete="email" required />
+            </div>
+            <div class="form-field">
+              <label for="mensaje">Mensaje</label>
+              <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Enviar mensaje</button>
+            <p class="form-status" role="status" aria-live="polite"></p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>© <span id="year"></span> Juana Saavedra. Todos los derechos reservados.</p>
+        <ul class="footer-links">
+          <li><a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a></li>
+          <li><a href="https://www.behance.net" target="_blank" rel="noreferrer">Behance</a></li>
+          <li><a href="mailto:jusaavedrar@ieee.org">Email</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,544 @@
+:root {
+  --bg: #0b0f14;
+  --surface: #111827;
+  --ink: #f3f4f6;
+  --ink-soft: rgba(243, 244, 246, 0.72);
+  --pink-300: #ff7bb6;
+  --pink-500: #ff5da2;
+  --pink-600: #e9488c;
+  --line: rgba(255, 255, 255, 0.08);
+  --radius-lg: 16px;
+  --shadow-soft: 0 24px 60px rgba(3, 8, 20, 0.35);
+  --shadow-card: 0 16px 40px rgba(8, 12, 24, 0.28);
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: "SF Pro Display", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: var(--bg);
+  color: var(--ink);
+  min-height: 100vh;
+  line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+  background-image:
+    linear-gradient(
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px
+    );
+  background-size: 60px 60px;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.5' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.12'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+  opacity: 0.4;
+  z-index: 1;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--pink-300);
+}
+
+:focus-visible {
+  outline: 2px solid var(--pink-500);
+  outline-offset: 4px;
+}
+
+.container {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.section {
+  padding: 120px 0;
+}
+
+.section-title {
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  margin-bottom: 48px;
+  color: var(--ink);
+}
+
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 24px 0;
+  z-index: 10;
+  transition: backdrop-filter 0.3s ease, background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.site-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  backdrop-filter: none;
+  border-bottom: 1px solid transparent;
+  border-radius: 0 0 24px 24px;
+  transition: inherit;
+  z-index: -1;
+}
+
+.site-header.is-glass::after {
+  backdrop-filter: blur(18px);
+  background-color: rgba(11, 15, 20, 0.72);
+  border-color: var(--line);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+}
+
+.brand-name {
+  font-weight: 600;
+}
+
+.site-nav ul {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  list-style: none;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 160px 0 120px;
+}
+
+.hero-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  opacity: 0.85;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(11, 15, 20, 0.8) 0%, rgba(11, 15, 20, 0.95) 100%);
+  z-index: 1;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  text-align: left;
+  max-width: 720px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.75rem;
+  color: var(--pink-300);
+  margin-bottom: 24px;
+}
+
+.hero-title {
+  font-size: clamp(3rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  margin-bottom: 24px;
+}
+
+.hero-subtitle {
+  font-size: 1.05rem;
+  color: var(--ink-soft);
+  margin-bottom: 40px;
+}
+
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 28px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+  border: 1px solid transparent;
+  position: relative;
+  overflow: hidden;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, var(--pink-600), var(--pink-500));
+  color: #0b0f14;
+  box-shadow: 0 18px 40px rgba(255, 93, 162, 0.28);
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 24px 60px rgba(255, 93, 162, 0.32);
+}
+
+.btn-ghost {
+  border-color: var(--line);
+  color: var(--ink);
+  background: rgba(17, 24, 39, 0.3);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible {
+  border-color: var(--pink-500);
+  color: var(--pink-300);
+}
+
+.services-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 32px;
+}
+
+.service-card {
+  background: rgba(17, 24, 39, 0.7);
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.5s ease, box-shadow 0.5s ease;
+  isolation: isolate;
+}
+
+.service-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  background: linear-gradient(120deg, rgba(255, 123, 182, 0.0), rgba(255, 93, 162, 0.6)) border-box;
+  mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0) border-box;
+  mask-composite: exclude;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
+  z-index: -1;
+}
+
+.service-card h3 {
+  font-size: 1.4rem;
+  margin-bottom: 16px;
+}
+
+.service-card p {
+  color: var(--ink-soft);
+}
+
+.service-card:hover,
+.service-card:focus-within {
+  transform: translateY(-10px) rotate3d(1, -1, 0, 4deg);
+  box-shadow: var(--shadow-card);
+}
+
+.service-card:hover::before,
+.service-card:focus-within::before {
+  transform: scaleX(1);
+}
+
+.service-card h3 em {
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0% 2px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.5s ease;
+}
+
+.service-card:hover h3 em,
+.service-card:focus-within h3 em {
+  background-size: 100% 2px;
+}
+
+.works-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+}
+
+.work-card {
+  background: rgba(17, 24, 39, 0.6);
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  transition: transform 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.work-card:hover,
+.work-card:focus-within {
+  transform: translateY(-8px);
+  border-color: rgba(255, 93, 162, 0.4);
+  box-shadow: 0 16px 40px rgba(8, 12, 24, 0.28);
+}
+
+.work-media {
+  aspect-ratio: 16 / 9;
+  background-image: repeating-linear-gradient(45deg, rgba(255, 123, 182, 0.35) 0, rgba(255, 123, 182, 0.35) 2px, transparent 2px, transparent 8px),
+    linear-gradient(135deg, rgba(255, 93, 162, 0.35), rgba(17, 24, 39, 0.6));
+  border-bottom: 1px solid var(--line);
+}
+
+.work-content {
+  padding: 24px;
+}
+
+.work-tags {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pink-300);
+  margin-bottom: 12px;
+}
+
+.about {
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.skill-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.skill-list li {
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(255, 93, 162, 0.16);
+  border: 1px solid rgba(255, 93, 162, 0.24);
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+}
+
+.about-logos {
+  display: grid;
+  gap: 24px;
+}
+
+.about-logos svg {
+  width: 100%;
+  height: auto;
+  background: rgba(17, 24, 39, 0.6);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  border: 1px solid var(--line);
+}
+
+.contact-form {
+  background: rgba(17, 24, 39, 0.8);
+  padding: 40px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 24px;
+  max-width: 560px;
+}
+
+.form-field {
+  display: grid;
+  gap: 8px;
+}
+
+label {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+input,
+textarea {
+  background: rgba(11, 15, 20, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 14px 16px;
+  color: var(--ink);
+  font: inherit;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.input-error {
+  border-color: var(--pink-600) !important;
+  box-shadow: 0 0 0 3px rgba(233, 72, 140, 0.26) !important;
+}
+
+input:focus-visible,
+textarea:focus-visible {
+  border-color: var(--pink-500);
+  box-shadow: 0 0 0 4px rgba(255, 93, 162, 0.18);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.form-status {
+  min-height: 1em;
+  font-size: 0.9rem;
+  color: var(--pink-300);
+}
+
+.site-footer {
+  border-top: 1px solid var(--line);
+  padding: 48px 0;
+  background: rgba(11, 15, 20, 0.86);
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.footer-links {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+}
+
+.footer-links a {
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+}
+
+.intro-mask {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  background: #000;
+  clip-path: circle(120% at 50% 50%);
+  transition: clip-path 0.8s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.intro-mask.is-hidden {
+  clip-path: circle(0% at 50% 50%);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  filter: blur(6px);
+  transition: opacity 0.8s ease, transform 0.8s ease, filter 0.8s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+  filter: blur(0);
+}
+
+.btn-magnetic {
+  will-change: transform;
+}
+
+@media (max-width: 720px) {
+  .site-nav ul {
+    gap: 16px;
+    font-size: 0.85rem;
+  }
+
+  .section {
+    padding: 96px 0;
+  }
+
+  .hero {
+    padding-top: 140px;
+  }
+
+  .contact-form {
+    padding: 32px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  body {
+    background-image: none;
+  }
+
+  body::before,
+  .intro-mask,
+  .hero-canvas {
+    display: none;
+  }
+
+  .reveal {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the previous Next.js project with a static single-page portfolio for Juana Saavedra
- add dark elegant styling, interactive reveals, and hero particle canvas driven purely by CSS and vanilla JavaScript
- implement accessible contact form validation, navigation, and motion preferences without external dependencies

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e534de8d4c8329a5c8707dcef2e07b